### PR TITLE
Prefer pinning to a commit hash versus a version tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Say hello
-        uses: cisagov/skeleton-action-composite@v1
+        uses: cisagov/skeleton-action-composite@3941c019a43e9726231b19390126b37ffda86f58 # v1.0.1
 ```
 
 ## New Repositories from a Skeleton ##


### PR DESCRIPTION
## 🗣 Description ##

This pull request changes the documentation to pin to a commit hash versus a version tag.

## 💭 Motivation and context ##

Pinning to a commit hash is more secure since version tags can be maliciously moved.

Resolves cisagov/action-disable-apparmor#4.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.