### PR TITLE
Adjust table headers to match compact style

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ appropriate for the major languages that we use.
 None.
 <!--
 | Name | Description | Interpreted Type | Default | Required |
-|------|-------------|------------------|---------|:--------:|
+| ---- | ----------- | ---------------- | ------- | :------: |
 | input_name | The input's description. | `string` | n/a | yes |
 -->
 
@@ -29,7 +29,7 @@ None.
 None.
 <!--
 | Name | Description | Output Type |
-|------|-------------|-------------|
+| ---- | ----------- | ----------- |
 | output_name | The output's description. | `output_type` |
 -->
 


### PR DESCRIPTION
## 🗣 Description ##

This pull request adjusts (commented out) table headers by adding whitespace to match the Markdown compact style.

## 💭 Motivation and context ##

This gets rid of some errors from our `markdownlint` `pre-commit` hook, should these tables be uncommented downstream.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
